### PR TITLE
Update functions.sh (run_process function)

### DIFF
--- a/0.Foundation/functions.sh
+++ b/0.Foundation/functions.sh
@@ -41,7 +41,6 @@ function run_process {
   local retryCount=0
   local command="$1"
   local logFile=$2
-  logFile="$aaaRoot/$logFile"
   while [[ $exitStatus -ne 0 && $retryCount -lt 3 ]]; do
     $command 1> $logFile.out 2> $logFile.err
     exitStatus=$?


### PR DESCRIPTION
Within the run_process function
logFile="$aaaRoot/$logFile" should be removed as it is always called in the following pattern in the other script files customize.job.manager.sh and customize.gpu.sh: 
run_process "toto" $aaaRoot/$fileType

It drives to double prefix error, for instance leading to:  /usr/local/aaa//usr/local/aaa/mongo-create-admin-user /usr/local/aaa//usr/local/aaa/mongo-create-database-user /usr/local/aaa//usr/local/aaa/deadline-repository
/usr/local/aaa//usr/local/aaa/deadline-client

Logs files created according are therefore wrong.